### PR TITLE
feat: adding permission-boundary-aspects

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ A collection of heaviliy opinionated AWS CDK highlevel constructs.
 
 ## Libraries
 1. Utils - A collection of utility functions
+
+## Aspects
+1. [PermissionsBoundaryAspect](src/aspects) - A custom aspect that can be used to apply a permission boundary to all roles created in the contex. 

--- a/src/aspects/README.md
+++ b/src/aspects/README.md
@@ -1,0 +1,37 @@
+# Aspects
+
+## PermissionsBoundaryAspect
+
+As a best practice organizations enforce policies which require all custom IAM Roles created to be defined under
+a specific path and permission boundary. Well, this allows better governance and also prevents unintended privilege escalation.
+
+AWS CDK high level constructs and patterns encapsulates the role creation from end users. So it is a laborious and at times impossible to get a handle of newly created roles within a stack.
+
+This aspect will scan all roles within the given scope and will attach the right permission boundary and path to them.
+
+### Usage
+```ts
+// can be used with any construct, perferred to be applied at the root/application level. 
+const app = new App();
+const mystack = new MyStack(app, 'MyConstruct'); // assuming this will create a role by name `myCodeBuildRole` with admin access.
+Aspects.of(app).add(new PermissionsBoundaryAspect('/my/devroles/', 'boundary/dev-max'));
+```
+#### Output
+```
+myCodeBuildRole1A2FE32J:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+        Version: 2012-10-17
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AdministratorAccess'
+      RoleName: myCodeBuildRole
+      Path: /my/devroles/
+      PermissionsBoundary: !Sub >-
+        arn:aws:iam::${AWS::AccountId}:policy/boundary/dev-max
+```

--- a/src/aspects/permission-boundary-aspect.ts
+++ b/src/aspects/permission-boundary-aspect.ts
@@ -1,0 +1,49 @@
+import { IAspect, Stack } from 'aws-cdk-lib';
+import { CfnRole, Role } from 'aws-cdk-lib/aws-iam';
+import { IConstruct } from 'constructs';
+
+/**
+ * As a best practice organizations enforce policies which require all custom IAM Roles created to be defined under
+ * a specific path and permission boundary. Well, this allows better governance and also prevents unintended privilege escalation.
+ * AWS CDK high level constructs and patterns encapsulates the role creation from end users.
+ * So it is a laborious and at times impossible to get a handle of newly created roles within a stack.
+ * This aspect will scan all roles within the given scope and will attach the right permission boundary and path to them.
+ */
+export class PermissionsBoundaryAspect implements IAspect {
+  /**
+   * The role path to attach to newly created roles.
+   */
+  rolePath: string;
+
+  /**
+   * The permission boundary to attach to newly created roles.
+   */
+  rolePermissionBoundary: string;
+
+  /**
+   * Constructs a new PermissionsBoundaryAspect.
+   * @param rolePath - the role path to attach to newly created roles.
+   * @param rolePermissionBoundary - the permission boundary to attach to newly created roles.
+   */
+  public constructor(rolePath: string, rolePermissionBoundary: string) {
+    this.rolePath = rolePath;
+    this.rolePermissionBoundary = rolePermissionBoundary;
+  }
+
+  public visit(node: IConstruct): void {
+
+    if (node instanceof Role) {
+      const stack = Stack.of(node);
+      const roleResource = node.node.findChild('Resource') as CfnRole;
+      // set the path if it is provided
+      if (this.rolePath) {
+        roleResource.addPropertyOverride('Path', this.rolePath);
+      }
+      // set the permission boundary if it is provided
+      if (this.rolePermissionBoundary && !this.rolePermissionBoundary.startsWith('arn:aws:iam')) {
+        roleResource.addPropertyOverride('PermissionsBoundary', `arn:aws:iam::${stack.account}:policy/${this.rolePermissionBoundary}`);
+      }
+    }
+
+  }
+}

--- a/test/aspects/permission-boundary-aspects.test.ts
+++ b/test/aspects/permission-boundary-aspects.test.ts
@@ -1,0 +1,39 @@
+import { App, Aspects, Stack } from 'aws-cdk-lib';
+import '@aws-cdk/assert/jest';
+import { PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+import { PermissionsBoundaryAspect } from '../../src/aspects/permission-boundary-aspect';
+
+export class MyStack extends Stack {
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id, { env: { account: '111111111111', region: 'us-east-1' } });
+
+    const role = new Role(this, 'MyRole', {
+      roleName: 'biju-test-role',
+      assumedBy: new ServicePrincipal('sns.amazonaws.com'),
+    });
+
+    role.addToPolicy(new PolicyStatement({
+      resources: ['*'],
+      actions: ['lambda:InvokeFunction'],
+    }));
+  }
+}
+
+describe('PermissionBoundaryAspect', () => {
+
+  test('Aspect will apply the correct path and boundary', () => {
+    const app = new App();
+    const mystack = new MyStack(app, 'MyConstruct');
+    Aspects.of(app).add(new PermissionsBoundaryAspect('/role/dev/', 'boundary/dev'));
+    app.synth();
+    expect(mystack).toHaveResourceLike('AWS::IAM::Role', {
+      RoleName: 'biju-test-role',
+      Path: '/role/dev/',
+      PermissionsBoundary: 'arn:aws:iam::111111111111:policy/boundary/dev',
+    });
+
+  });
+
+});


### PR DESCRIPTION
Adding permission boundary aspect. 

## Motivation

**PermissionsBoundaryAspect**

As a best practice organizations enforce policies which require all custom IAM Roles created to be defined under
a specific path and permission boundary. Well, this allows better governance and also prevents unintended privilege escalation.

AWS CDK high level constructs and patterns encapsulates the role creation from end users. So it is a laborious and at times impossible to get a handle of newly created roles within a stack.

This aspect will scan all roles within the given scope and will attach the right permission boundary and path to them.

### Usage
```ts
// can be used with any construct, perferred to be applied at the root/application level. 
const app = new App();
const mystack = new MyStack(app, 'MyConstruct'); // assuming this will create a role by name `myCodeBuildRole` with admin access.
Aspects.of(app).add(new PermissionsBoundaryAspect('/my/devroles/', 'boundary/dev-max'));
```
#### Output
```
myCodeBuildRole1A2FE32J:
    Type: 'AWS::IAM::Role'
    Properties:
      AssumeRolePolicyDocument:
        Statement:
          - Action: 'sts:AssumeRole'
            Effect: Allow
            Principal:
              Service: codebuild.amazonaws.com
        Version: 2012-10-17
      ManagedPolicyArns:
        - 'arn:aws:iam::aws:policy/AdministratorAccess'
      RoleName: myCodeBuildRole
      Path: /my/devroles/
      PermissionsBoundary: !Sub >-
        arn:aws:iam::${AWS::AccountId}:policy/boundary/dev-max
```
