### PR TITLE
feat: adding custom CDK synthesizer .

### DIFF
--- a/API.md
+++ b/API.md
@@ -542,6 +542,7 @@ new Utils()
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#ez-constructs.Utils.appendIfNecessary">appendIfNecessary</a></code> | Will append the suffix to the given name if the name do not contain the suffix. |
+| <code><a href="#ez-constructs.Utils.wrap">wrap</a></code> | Will wrap the given string using the given delimiter. |
 
 ---
 
@@ -568,6 +569,32 @@ a string.
 - *Type:* string
 
 the string to append.
+
+---
+
+##### `wrap` <a name="wrap" id="ez-constructs.Utils.wrap"></a>
+
+```typescript
+import { Utils } from 'ez-constructs'
+
+Utils.wrap(str: string, delimiter: string)
+```
+
+Will wrap the given string using the given delimiter.
+
+###### `str`<sup>Required</sup> <a name="str" id="ez-constructs.Utils.wrap.parameter.str"></a>
+
+- *Type:* string
+
+the string to wrap.
+
+---
+
+###### `delimiter`<sup>Required</sup> <a name="delimiter" id="ez-constructs.Utils.wrap.parameter.delimiter"></a>
+
+- *Type:* string
+
+the delimiter to use.
 
 ---
 

--- a/src/lib/custom-synthesizer.ts
+++ b/src/lib/custom-synthesizer.ts
@@ -1,0 +1,39 @@
+import { DefaultStackSynthesizer } from 'aws-cdk-lib';
+import { Utils } from './utils';
+
+/**
+ * As a best practice organizations enforce policies which require all custom IAM Roles created to be defined under
+ * a specific path and permission boundary.
+ * In order to adhere with such compliance requirements, the CDK bootstrapping is often customized
+ * (refer: https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html#bootstrapping-customizing).
+ * So, we need to ensure that parallel customization is applied during synthesis phase.
+ * This Custom Synthesizer is used to modify the default path of the following IAM Roles internally used by CDK:
+ *  - deploy role
+ *  - file-publishing-role
+ *  - image-publishing-role
+ *  - cfn-exec-role
+ *  - lookup-role
+
+ * @see PermissionsBoundaryAspect
+ */
+export class CustomSynthesizer extends DefaultStackSynthesizer {
+
+  private static qualifiedRole(roleName: string, rolePath: string): string {
+    return 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role' +
+      Utils.wrap(rolePath, '/') +
+      'cdk-${Qualifier}-' +
+      roleName +
+      '-${AWS::AccountId}-${AWS::Region}';
+  }
+
+  constructor(rolePath: string) {
+    super({
+      deployRoleArn: CustomSynthesizer.qualifiedRole('deploy-role', rolePath),
+      fileAssetPublishingRoleArn: CustomSynthesizer.qualifiedRole('file-publishing-role', rolePath),
+      imageAssetPublishingRoleArn: CustomSynthesizer.qualifiedRole('image-publishing-role', rolePath),
+      cloudFormationExecutionRole: CustomSynthesizer.qualifiedRole('cfn-exec-role', rolePath),
+      lookupRoleArn: CustomSynthesizer.qualifiedRole('lookup-role', rolePath),
+    });
+  }
+
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -19,4 +19,17 @@ export class Utils {
 
     return newName;
   }
+
+  /**
+   * Will wrap the given string using the given delimiter.
+   * @param str - the string to wrap
+   * @param delimiter - the delimiter to use
+   * @returns the wrapped string
+   */
+  public static wrap(str:string, delimiter:string): string {
+    let newStr = str;
+    if (!_.startsWith(str, delimiter)) newStr = `${delimiter}${newStr}`;
+    if (!_.endsWith(str, delimiter)) newStr = `${newStr}${delimiter}`;
+    return newStr;
+  }
 }

--- a/test/lib/custom-synthesizer.test.ts
+++ b/test/lib/custom-synthesizer.test.ts
@@ -1,0 +1,68 @@
+import { App, Stack } from 'aws-cdk-lib';
+import * as _ from 'lodash';
+import { CustomSynthesizer } from '../../src/lib/custom-synthesizer';
+
+
+describe('CustomSynthesizer', () => {
+  test('should be able to create a custom synthesizer', () => {
+    let synthesizer = new CustomSynthesizer('myorg/rolepath');
+    expect(synthesizer).toBeTruthy();
+  });
+  test('should be able to see the correct role paths', () => {
+    // GIVEN
+    const myapp = new App();
+
+    // WHEN
+    new Stack(myapp, 'mystack', {
+      synthesizer: new CustomSynthesizer('myorg/rolepath'),
+      env: { account: '111111111111', region: 'us-east-1' },
+    });
+
+    let assembly = myapp.synth();
+
+    // THEN
+    let cfArtifact = assembly.artifacts.find(a => a.id == 'mystack') || {};
+    expect(_.get(cfArtifact, 'assumeRoleArn'))
+      .toEqual('arn:${AWS::Partition}:iam::111111111111:role/myorg/rolepath/cdk-hnb659fds-deploy-role-111111111111-us-east-1');
+    expect(_.get(cfArtifact, 'cloudFormationExecutionRoleArn'))
+      .toEqual('arn:${AWS::Partition}:iam::111111111111:role/myorg/rolepath/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1');
+  });
+  test('should be able to see the correct role paths when roles already have slash prefix', () => {
+    // GIVEN
+    const myapp = new App();
+
+    // WHEN
+    new Stack(myapp, 'mystack', {
+      synthesizer: new CustomSynthesizer('/myorg/rolepath'),
+      env: { account: '111111111111', region: 'us-east-1' },
+    });
+
+    let assembly = myapp.synth();
+
+    // THEN
+    let cfArtifact = assembly.artifacts.find(a => a.id == 'mystack') || {};
+    expect(_.get(cfArtifact, 'assumeRoleArn'))
+      .toEqual('arn:${AWS::Partition}:iam::111111111111:role/myorg/rolepath/cdk-hnb659fds-deploy-role-111111111111-us-east-1');
+    expect(_.get(cfArtifact, 'cloudFormationExecutionRoleArn'))
+      .toEqual('arn:${AWS::Partition}:iam::111111111111:role/myorg/rolepath/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1');
+  });
+  test('should be able to see the correct role paths when roles already have slash suffix', () => {
+    // GIVEN
+    const myapp = new App();
+
+    // WHEN
+    new Stack(myapp, 'mystack', {
+      synthesizer: new CustomSynthesizer('myorg/rolepath/'),
+      env: { account: '111111111111', region: 'us-east-1' },
+    });
+
+    let assembly = myapp.synth();
+
+    // THEN
+    let cfArtifact = assembly.artifacts.find(a => a.id == 'mystack') || {};
+    expect(_.get(cfArtifact, 'assumeRoleArn'))
+      .toEqual('arn:${AWS::Partition}:iam::111111111111:role/myorg/rolepath/cdk-hnb659fds-deploy-role-111111111111-us-east-1');
+    expect(_.get(cfArtifact, 'cloudFormationExecutionRoleArn'))
+      .toEqual('arn:${AWS::Partition}:iam::111111111111:role/myorg/rolepath/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1');
+  });
+});

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -2,15 +2,33 @@ import { Utils } from '../../src/lib/utils';
 
 
 describe('Utils', () => {
-  test('should append suffixes', () => {
-    expect(Utils.appendIfNecessary('hello', 'world', 'again')).toBe('hello-world-again');
-  });
-  test('should append suffixes only if needed', () => {
-    expect(Utils.appendIfNecessary('hello-world', 'world', 'again')).toBe('hello-world-again');
-  });
 
-  test('should not append suffixes when not provided', () => {
-    expect(Utils.appendIfNecessary('hello-world')).toBe('hello-world');
+  describe('appendIfNecessry', () => {
+    test('should append suffixes', () => {
+      expect(Utils.appendIfNecessary('hello', 'world', 'again')).toBe('hello-world-again');
+    });
+    test('should append suffixes only if needed', () => {
+      expect(Utils.appendIfNecessary('hello-world', 'world', 'again')).toBe('hello-world-again');
+    });
+
+    test('should not append suffixes when not provided', () => {
+      expect(Utils.appendIfNecessary('hello-world')).toBe('hello-world');
+    });
+  });
+  describe('wrap', () => {
+
+    test('should add suffix and prefix', () => {
+      expect(Utils.wrap('hello/world', '/')).toBe('/hello/world/');
+    });
+    test('should add suffix if needed', () => {
+      expect(Utils.wrap('/hello/world', '/')).toBe('/hello/world/');
+    });
+    test('should add prefix if needed', () => {
+      expect(Utils.wrap('hello/world/', '/')).toBe('/hello/world/');
+    });
+    test('should add suffix and prefix only if needed', () => {
+      expect(Utils.wrap('/hello/world/', '/')).toBe('/hello/world/');
+    });
   });
 
 });


### PR DESCRIPTION
**Motivation**
As a best practice organizations enforce policies which require all custom IAM Roles created to be defined under
 a specific path and permission boundary.
 In order to adhere with such compliance requirements, the CDK bootstrapping is often customized
(refer: https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping.html#bootstrapping-customizing).
So, we need to ensure that parallel customization is applied during synthesis phase.
This Custom Synthesizer is used to modify the default path of the following IAM Roles internally used by CDK:
- deploy role
- file-publishing-role
- image-publishing-role
- cfn-exec-role
- lookup-role