### PR TITLE
feat: adding builder and codebuild construct

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,51 +2,34 @@
 
 ## Constructs <a name="Constructs" id="Constructs"></a>
 
-### SecureBucket <a name="SecureBucket" id="ez-constructs.SecureBucket"></a>
+### EzConstruct <a name="EzConstruct" id="ez-constructs.EzConstruct"></a>
 
-Will create a secure bucket with the following features: - Bucket name will be modified to include account and region.
+A marker base class for EzConstructs.
 
-Access limited to the owner - Object Versioning - Encryption at rest - Object expiration max limit to 10 years - Object will transition to IA after 60 days and later to deep archive after 365 days
-
-#### Initializers <a name="Initializers" id="ez-constructs.SecureBucket.Initializer"></a>
+#### Initializers <a name="Initializers" id="ez-constructs.EzConstruct.Initializer"></a>
 
 ```typescript
-import { SecureBucket } from 'ez-constructs'
+import { EzConstruct } from 'ez-constructs'
 
-new SecureBucket(scope: Construct, id: string, props: SecureBucketProps)
+new EzConstruct(scope: Construct, id: string)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#ez-constructs.SecureBucket.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | - the stack in which the construct is defined. |
-| <code><a href="#ez-constructs.SecureBucket.Initializer.parameter.id">id</a></code> | <code>string</code> | - a unique identifier for the construct. |
-| <code><a href="#ez-constructs.SecureBucket.Initializer.parameter.props">props</a></code> | <code><a href="#ez-constructs.SecureBucketProps">SecureBucketProps</a></code> | - the customized set of properies. |
+| <code><a href="#ez-constructs.EzConstruct.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
+| <code><a href="#ez-constructs.EzConstruct.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
 
 ---
 
-##### `scope`<sup>Required</sup> <a name="scope" id="ez-constructs.SecureBucket.Initializer.parameter.scope"></a>
+##### `scope`<sup>Required</sup> <a name="scope" id="ez-constructs.EzConstruct.Initializer.parameter.scope"></a>
 
 - *Type:* constructs.Construct
 
-the stack in which the construct is defined.
-
 ---
 
-##### `id`<sup>Required</sup> <a name="id" id="ez-constructs.SecureBucket.Initializer.parameter.id"></a>
+##### `id`<sup>Required</sup> <a name="id" id="ez-constructs.EzConstruct.Initializer.parameter.id"></a>
 
 - *Type:* string
-
-a unique identifier for the construct.
-
----
-
-##### `props`<sup>Required</sup> <a name="props" id="ez-constructs.SecureBucket.Initializer.parameter.props"></a>
-
-- *Type:* <a href="#ez-constructs.SecureBucketProps">SecureBucketProps</a>
-
-the customized set of properies.
-
-The `bucketName` property must be set.
 
 ---
 
@@ -54,11 +37,11 @@ The `bucketName` property must be set.
 
 | **Name** | **Description** |
 | --- | --- |
-| <code><a href="#ez-constructs.SecureBucket.toString">toString</a></code> | Returns a string representation of this construct. |
+| <code><a href="#ez-constructs.EzConstruct.toString">toString</a></code> | Returns a string representation of this construct. |
 
 ---
 
-##### `toString` <a name="toString" id="ez-constructs.SecureBucket.toString"></a>
+##### `toString` <a name="toString" id="ez-constructs.EzConstruct.toString"></a>
 
 ```typescript
 public toString(): string
@@ -67,455 +50,8 @@ public toString(): string
 Returns a string representation of this construct.
 
 
-#### Properties <a name="Properties" id="Properties"></a>
 
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#ez-constructs.SecureBucket.property.bucket">bucket</a></code> | <code>aws-cdk-lib.aws_s3.Bucket</code> | *No description.* |
 
----
-
-##### `bucket`<sup>Required</sup> <a name="bucket" id="ez-constructs.SecureBucket.property.bucket"></a>
-
-```typescript
-public readonly bucket: Bucket;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.Bucket
-
----
-
-
-## Structs <a name="Structs" id="Structs"></a>
-
-### SecureBucketProps <a name="SecureBucketProps" id="ez-constructs.SecureBucketProps"></a>
-
-Properties for a bucket.
-
-#### Initializer <a name="Initializer" id="ez-constructs.SecureBucketProps.Initializer"></a>
-
-```typescript
-import { SecureBucketProps } from 'ez-constructs'
-
-const secureBucketProps: SecureBucketProps = { ... }
-```
-
-#### Properties <a name="Properties" id="Properties"></a>
-
-| **Name** | **Type** | **Description** |
-| --- | --- | --- |
-| <code><a href="#ez-constructs.SecureBucketProps.property.accessControl">accessControl</a></code> | <code>aws-cdk-lib.aws_s3.BucketAccessControl</code> | Specifies a canned ACL that grants predefined permissions to the bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.autoDeleteObjects">autoDeleteObjects</a></code> | <code>boolean</code> | Whether all objects should be automatically deleted when the bucket is removed from the stack or when the stack is deleted. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.blockPublicAccess">blockPublicAccess</a></code> | <code>aws-cdk-lib.aws_s3.BlockPublicAccess</code> | The block public access configuration of this bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.bucketKeyEnabled">bucketKeyEnabled</a></code> | <code>boolean</code> | Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.bucketName">bucketName</a></code> | <code>string</code> | Physical name of this bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.cors">cors</a></code> | <code>aws-cdk-lib.aws_s3.CorsRule[]</code> | The CORS configuration of this bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.encryption">encryption</a></code> | <code>aws-cdk-lib.aws_s3.BucketEncryption</code> | The kind of server-side encryption to apply to this bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.encryptionKey">encryptionKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | External KMS key to use for bucket encryption. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.enforceSSL">enforceSSL</a></code> | <code>boolean</code> | Enforces SSL for requests. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.intelligentTieringConfigurations">intelligentTieringConfigurations</a></code> | <code>aws-cdk-lib.aws_s3.IntelligentTieringConfiguration[]</code> | Inteligent Tiering Configurations. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.inventories">inventories</a></code> | <code>aws-cdk-lib.aws_s3.Inventory[]</code> | The inventory configuration of the bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.lifecycleRules">lifecycleRules</a></code> | <code>aws-cdk-lib.aws_s3.LifecycleRule[]</code> | Rules that define how Amazon S3 manages objects during their lifetime. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.metrics">metrics</a></code> | <code>aws-cdk-lib.aws_s3.BucketMetrics[]</code> | The metrics configuration of this bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.notificationsHandlerRole">notificationsHandlerRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The role to be used by the notifications handler. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.objectOwnership">objectOwnership</a></code> | <code>aws-cdk-lib.aws_s3.ObjectOwnership</code> | The objectOwnership of the bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.publicReadAccess">publicReadAccess</a></code> | <code>boolean</code> | Grants public read access to all objects in the bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.removalPolicy">removalPolicy</a></code> | <code>aws-cdk-lib.RemovalPolicy</code> | Policy to apply when the bucket is removed from this stack. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.serverAccessLogsBucket">serverAccessLogsBucket</a></code> | <code>aws-cdk-lib.aws_s3.IBucket</code> | Destination bucket for the server access logs. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.serverAccessLogsPrefix">serverAccessLogsPrefix</a></code> | <code>string</code> | Optional log file prefix to use for the bucket's access logs. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.transferAcceleration">transferAcceleration</a></code> | <code>boolean</code> | Whether this bucket should have transfer acceleration turned on or not. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.versioned">versioned</a></code> | <code>boolean</code> | Whether this bucket should have versioning turned on or not. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.websiteErrorDocument">websiteErrorDocument</a></code> | <code>string</code> | The name of the error document (e.g. "404.html") for the website. `websiteIndexDocument` must also be set if this is set. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.websiteIndexDocument">websiteIndexDocument</a></code> | <code>string</code> | The name of the index document (e.g. "index.html") for the website. Enables static website hosting for this bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.websiteRedirect">websiteRedirect</a></code> | <code>aws-cdk-lib.aws_s3.RedirectTarget</code> | Specifies the redirect behavior of all requests to a website endpoint of a bucket. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.websiteRoutingRules">websiteRoutingRules</a></code> | <code>aws-cdk-lib.aws_s3.RoutingRule[]</code> | Rules that define when a redirect is applied and the redirect behavior. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.moveToGlacierDeepArchive">moveToGlacierDeepArchive</a></code> | <code>boolean</code> | Use only for buckets that have archiving data. |
-| <code><a href="#ez-constructs.SecureBucketProps.property.objectsExpireInDays">objectsExpireInDays</a></code> | <code>number</code> | The number of days that object will be kept. |
-
----
-
-##### `accessControl`<sup>Optional</sup> <a name="accessControl" id="ez-constructs.SecureBucketProps.property.accessControl"></a>
-
-```typescript
-public readonly accessControl: BucketAccessControl;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.BucketAccessControl
-- *Default:* BucketAccessControl.PRIVATE
-
-Specifies a canned ACL that grants predefined permissions to the bucket.
-
----
-
-##### `autoDeleteObjects`<sup>Optional</sup> <a name="autoDeleteObjects" id="ez-constructs.SecureBucketProps.property.autoDeleteObjects"></a>
-
-```typescript
-public readonly autoDeleteObjects: boolean;
-```
-
-- *Type:* boolean
-- *Default:* false
-
-Whether all objects should be automatically deleted when the bucket is removed from the stack or when the stack is deleted.
-
-Requires the `removalPolicy` to be set to `RemovalPolicy.DESTROY`.  **Warning** if you have deployed a bucket with `autoDeleteObjects: true`, switching this to `false` in a CDK version *before* `1.126.0` will lead to all objects in the bucket being deleted. Be sure to update your bucket resources by deploying with CDK version `1.126.0` or later **before** switching this value to `false`.
-
----
-
-##### `blockPublicAccess`<sup>Optional</sup> <a name="blockPublicAccess" id="ez-constructs.SecureBucketProps.property.blockPublicAccess"></a>
-
-```typescript
-public readonly blockPublicAccess: BlockPublicAccess;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.BlockPublicAccess
-- *Default:* CloudFormation defaults will apply. New buckets and objects don't allow public access, but users can modify bucket policies or object permissions to allow public access
-
-The block public access configuration of this bucket.
-
-> [https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html)
-
----
-
-##### `bucketKeyEnabled`<sup>Optional</sup> <a name="bucketKeyEnabled" id="ez-constructs.SecureBucketProps.property.bucketKeyEnabled"></a>
-
-```typescript
-public readonly bucketKeyEnabled: boolean;
-```
-
-- *Type:* boolean
-- *Default:* false
-
-Specifies whether Amazon S3 should use an S3 Bucket Key with server-side encryption using KMS (SSE-KMS) for new objects in the bucket.
-
-Only relevant, when Encryption is set to {@link BucketEncryption.KMS}
-
----
-
-##### `bucketName`<sup>Optional</sup> <a name="bucketName" id="ez-constructs.SecureBucketProps.property.bucketName"></a>
-
-```typescript
-public readonly bucketName: string;
-```
-
-- *Type:* string
-- *Default:* Assigned by CloudFormation (recommended).
-
-Physical name of this bucket.
-
----
-
-##### `cors`<sup>Optional</sup> <a name="cors" id="ez-constructs.SecureBucketProps.property.cors"></a>
-
-```typescript
-public readonly cors: CorsRule[];
-```
-
-- *Type:* aws-cdk-lib.aws_s3.CorsRule[]
-- *Default:* No CORS configuration.
-
-The CORS configuration of this bucket.
-
-> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-cors.html)
-
----
-
-##### `encryption`<sup>Optional</sup> <a name="encryption" id="ez-constructs.SecureBucketProps.property.encryption"></a>
-
-```typescript
-public readonly encryption: BucketEncryption;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.BucketEncryption
-- *Default:* `Kms` if `encryptionKey` is specified, or `Unencrypted` otherwise.
-
-The kind of server-side encryption to apply to this bucket.
-
-If you choose KMS, you can specify a KMS key via `encryptionKey`. If encryption key is not specified, a key will automatically be created.
-
----
-
-##### `encryptionKey`<sup>Optional</sup> <a name="encryptionKey" id="ez-constructs.SecureBucketProps.property.encryptionKey"></a>
-
-```typescript
-public readonly encryptionKey: IKey;
-```
-
-- *Type:* aws-cdk-lib.aws_kms.IKey
-- *Default:* If encryption is set to "Kms" and this property is undefined, a new KMS key will be created and associated with this bucket.
-
-External KMS key to use for bucket encryption.
-
-The 'encryption' property must be either not specified or set to "Kms". An error will be emitted if encryption is set to "Unencrypted" or "Managed".
-
----
-
-##### `enforceSSL`<sup>Optional</sup> <a name="enforceSSL" id="ez-constructs.SecureBucketProps.property.enforceSSL"></a>
-
-```typescript
-public readonly enforceSSL: boolean;
-```
-
-- *Type:* boolean
-- *Default:* false
-
-Enforces SSL for requests.
-
-S3.5 of the AWS Foundational Security Best Practices Regarding S3.
-
-> [https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html](https://docs.aws.amazon.com/config/latest/developerguide/s3-bucket-ssl-requests-only.html)
-
----
-
-##### `intelligentTieringConfigurations`<sup>Optional</sup> <a name="intelligentTieringConfigurations" id="ez-constructs.SecureBucketProps.property.intelligentTieringConfigurations"></a>
-
-```typescript
-public readonly intelligentTieringConfigurations: IntelligentTieringConfiguration[];
-```
-
-- *Type:* aws-cdk-lib.aws_s3.IntelligentTieringConfiguration[]
-- *Default:* No Intelligent Tiiering Configurations.
-
-Inteligent Tiering Configurations.
-
-> [https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html)
-
----
-
-##### `inventories`<sup>Optional</sup> <a name="inventories" id="ez-constructs.SecureBucketProps.property.inventories"></a>
-
-```typescript
-public readonly inventories: Inventory[];
-```
-
-- *Type:* aws-cdk-lib.aws_s3.Inventory[]
-- *Default:* No inventory configuration
-
-The inventory configuration of the bucket.
-
-> [https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html)
-
----
-
-##### `lifecycleRules`<sup>Optional</sup> <a name="lifecycleRules" id="ez-constructs.SecureBucketProps.property.lifecycleRules"></a>
-
-```typescript
-public readonly lifecycleRules: LifecycleRule[];
-```
-
-- *Type:* aws-cdk-lib.aws_s3.LifecycleRule[]
-- *Default:* No lifecycle rules.
-
-Rules that define how Amazon S3 manages objects during their lifetime.
-
----
-
-##### `metrics`<sup>Optional</sup> <a name="metrics" id="ez-constructs.SecureBucketProps.property.metrics"></a>
-
-```typescript
-public readonly metrics: BucketMetrics[];
-```
-
-- *Type:* aws-cdk-lib.aws_s3.BucketMetrics[]
-- *Default:* No metrics configuration.
-
-The metrics configuration of this bucket.
-
-> [https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-metricsconfiguration.html](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket-metricsconfiguration.html)
-
----
-
-##### `notificationsHandlerRole`<sup>Optional</sup> <a name="notificationsHandlerRole" id="ez-constructs.SecureBucketProps.property.notificationsHandlerRole"></a>
-
-```typescript
-public readonly notificationsHandlerRole: IRole;
-```
-
-- *Type:* aws-cdk-lib.aws_iam.IRole
-- *Default:* a new role will be created.
-
-The role to be used by the notifications handler.
-
----
-
-##### `objectOwnership`<sup>Optional</sup> <a name="objectOwnership" id="ez-constructs.SecureBucketProps.property.objectOwnership"></a>
-
-```typescript
-public readonly objectOwnership: ObjectOwnership;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.ObjectOwnership
-- *Default:* No ObjectOwnership configuration, uploading account will own the object.
-
-The objectOwnership of the bucket.
-
-> [https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html](https://docs.aws.amazon.com/AmazonS3/latest/dev/about-object-ownership.html)
-
----
-
-##### `publicReadAccess`<sup>Optional</sup> <a name="publicReadAccess" id="ez-constructs.SecureBucketProps.property.publicReadAccess"></a>
-
-```typescript
-public readonly publicReadAccess: boolean;
-```
-
-- *Type:* boolean
-- *Default:* false
-
-Grants public read access to all objects in the bucket.
-
-Similar to calling `bucket.grantPublicAccess()`
-
----
-
-##### `removalPolicy`<sup>Optional</sup> <a name="removalPolicy" id="ez-constructs.SecureBucketProps.property.removalPolicy"></a>
-
-```typescript
-public readonly removalPolicy: RemovalPolicy;
-```
-
-- *Type:* aws-cdk-lib.RemovalPolicy
-- *Default:* The bucket will be orphaned.
-
-Policy to apply when the bucket is removed from this stack.
-
----
-
-##### `serverAccessLogsBucket`<sup>Optional</sup> <a name="serverAccessLogsBucket" id="ez-constructs.SecureBucketProps.property.serverAccessLogsBucket"></a>
-
-```typescript
-public readonly serverAccessLogsBucket: IBucket;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.IBucket
-- *Default:* If "serverAccessLogsPrefix" undefined - access logs disabled, otherwise - log to current bucket.
-
-Destination bucket for the server access logs.
-
----
-
-##### `serverAccessLogsPrefix`<sup>Optional</sup> <a name="serverAccessLogsPrefix" id="ez-constructs.SecureBucketProps.property.serverAccessLogsPrefix"></a>
-
-```typescript
-public readonly serverAccessLogsPrefix: string;
-```
-
-- *Type:* string
-- *Default:* No log file prefix
-
-Optional log file prefix to use for the bucket's access logs.
-
-If defined without "serverAccessLogsBucket", enables access logs to current bucket with this prefix.
-
----
-
-##### `transferAcceleration`<sup>Optional</sup> <a name="transferAcceleration" id="ez-constructs.SecureBucketProps.property.transferAcceleration"></a>
-
-```typescript
-public readonly transferAcceleration: boolean;
-```
-
-- *Type:* boolean
-- *Default:* false
-
-Whether this bucket should have transfer acceleration turned on or not.
-
----
-
-##### `versioned`<sup>Optional</sup> <a name="versioned" id="ez-constructs.SecureBucketProps.property.versioned"></a>
-
-```typescript
-public readonly versioned: boolean;
-```
-
-- *Type:* boolean
-- *Default:* false
-
-Whether this bucket should have versioning turned on or not.
-
----
-
-##### `websiteErrorDocument`<sup>Optional</sup> <a name="websiteErrorDocument" id="ez-constructs.SecureBucketProps.property.websiteErrorDocument"></a>
-
-```typescript
-public readonly websiteErrorDocument: string;
-```
-
-- *Type:* string
-- *Default:* No error document.
-
-The name of the error document (e.g. "404.html") for the website. `websiteIndexDocument` must also be set if this is set.
-
----
-
-##### `websiteIndexDocument`<sup>Optional</sup> <a name="websiteIndexDocument" id="ez-constructs.SecureBucketProps.property.websiteIndexDocument"></a>
-
-```typescript
-public readonly websiteIndexDocument: string;
-```
-
-- *Type:* string
-- *Default:* No index document.
-
-The name of the index document (e.g. "index.html") for the website. Enables static website hosting for this bucket.
-
----
-
-##### `websiteRedirect`<sup>Optional</sup> <a name="websiteRedirect" id="ez-constructs.SecureBucketProps.property.websiteRedirect"></a>
-
-```typescript
-public readonly websiteRedirect: RedirectTarget;
-```
-
-- *Type:* aws-cdk-lib.aws_s3.RedirectTarget
-- *Default:* No redirection.
-
-Specifies the redirect behavior of all requests to a website endpoint of a bucket.
-
-If you specify this property, you can't specify "websiteIndexDocument", "websiteErrorDocument" nor , "websiteRoutingRules".
-
----
-
-##### `websiteRoutingRules`<sup>Optional</sup> <a name="websiteRoutingRules" id="ez-constructs.SecureBucketProps.property.websiteRoutingRules"></a>
-
-```typescript
-public readonly websiteRoutingRules: RoutingRule[];
-```
-
-- *Type:* aws-cdk-lib.aws_s3.RoutingRule[]
-- *Default:* No redirection rules.
-
-Rules that define when a redirect is applied and the redirect behavior.
-
----
-
-##### `moveToGlacierDeepArchive`<sup>Optional</sup> <a name="moveToGlacierDeepArchive" id="ez-constructs.SecureBucketProps.property.moveToGlacierDeepArchive"></a>
-
-```typescript
-public readonly moveToGlacierDeepArchive: boolean;
-```
-
-- *Type:* boolean
-- *Default:* false
-
-Use only for buckets that have archiving data.
-
-CAUTION, once the object is archived, a temporary bucket to store the data.
-
----
-
-##### `objectsExpireInDays`<sup>Optional</sup> <a name="objectsExpireInDays" id="ez-constructs.SecureBucketProps.property.objectsExpireInDays"></a>
-
-```typescript
-public readonly objectsExpireInDays: number;
-```
-
-- *Type:* number
-- *Default:* 3650 - 10 years
-
-The number of days that object will be kept.
-
----
 
 ## Classes <a name="Classes" id="Classes"></a>
 
@@ -542,6 +78,12 @@ new Utils()
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#ez-constructs.Utils.appendIfNecessary">appendIfNecessary</a></code> | Will append the suffix to the given name if the name do not contain the suffix. |
+| <code><a href="#ez-constructs.Utils.endsWith">endsWith</a></code> | Will check if the given string ends with the given suffix. |
+| <code><a href="#ez-constructs.Utils.isEmpty">isEmpty</a></code> | Will check if the given object is empty. |
+| <code><a href="#ez-constructs.Utils.kebabCase">kebabCase</a></code> | Will convert the given string to lower case and transform any spaces to hyphens. |
+| <code><a href="#ez-constructs.Utils.parseGithubUrl">parseGithubUrl</a></code> | Splits a given Github URL and extracts the owner and repo name. |
+| <code><a href="#ez-constructs.Utils.prettyPrintStack">prettyPrintStack</a></code> | A utility function that will print the content of a CDK stack. |
+| <code><a href="#ez-constructs.Utils.startsWith">startsWith</a></code> | Will check if the given string starts with the given prefix. |
 | <code><a href="#ez-constructs.Utils.wrap">wrap</a></code> | Will wrap the given string using the given delimiter. |
 
 ---
@@ -569,6 +111,126 @@ a string.
 - *Type:* string
 
 the string to append.
+
+---
+
+##### `endsWith` <a name="endsWith" id="ez-constructs.Utils.endsWith"></a>
+
+```typescript
+import { Utils } from 'ez-constructs'
+
+Utils.endsWith(str: string, s: string)
+```
+
+Will check if the given string ends with the given suffix.
+
+###### `str`<sup>Required</sup> <a name="str" id="ez-constructs.Utils.endsWith.parameter.str"></a>
+
+- *Type:* string
+
+a string.
+
+---
+
+###### `s`<sup>Required</sup> <a name="s" id="ez-constructs.Utils.endsWith.parameter.s"></a>
+
+- *Type:* string
+
+suffix to check.
+
+---
+
+##### `isEmpty` <a name="isEmpty" id="ez-constructs.Utils.isEmpty"></a>
+
+```typescript
+import { Utils } from 'ez-constructs'
+
+Utils.isEmpty(value?: any)
+```
+
+Will check if the given object is empty.
+
+###### `value`<sup>Optional</sup> <a name="value" id="ez-constructs.Utils.isEmpty.parameter.value"></a>
+
+- *Type:* any
+
+---
+
+##### `kebabCase` <a name="kebabCase" id="ez-constructs.Utils.kebabCase"></a>
+
+```typescript
+import { Utils } from 'ez-constructs'
+
+Utils.kebabCase(str: string)
+```
+
+Will convert the given string to lower case and transform any spaces to hyphens.
+
+###### `str`<sup>Required</sup> <a name="str" id="ez-constructs.Utils.kebabCase.parameter.str"></a>
+
+- *Type:* string
+
+a string.
+
+---
+
+##### `parseGithubUrl` <a name="parseGithubUrl" id="ez-constructs.Utils.parseGithubUrl"></a>
+
+```typescript
+import { Utils } from 'ez-constructs'
+
+Utils.parseGithubUrl(url: string)
+```
+
+Splits a given Github URL and extracts the owner and repo name.
+
+###### `url`<sup>Required</sup> <a name="url" id="ez-constructs.Utils.parseGithubUrl.parameter.url"></a>
+
+- *Type:* string
+
+---
+
+##### `prettyPrintStack` <a name="prettyPrintStack" id="ez-constructs.Utils.prettyPrintStack"></a>
+
+```typescript
+import { Utils } from 'ez-constructs'
+
+Utils.prettyPrintStack(stack: Stack)
+```
+
+A utility function that will print the content of a CDK stack.
+
+###### `stack`<sup>Required</sup> <a name="stack" id="ez-constructs.Utils.prettyPrintStack.parameter.stack"></a>
+
+- *Type:* aws-cdk-lib.Stack
+
+a valid stack.
+
+---
+
+##### `startsWith` <a name="startsWith" id="ez-constructs.Utils.startsWith"></a>
+
+```typescript
+import { Utils } from 'ez-constructs'
+
+Utils.startsWith(str: string, s: string)
+```
+
+Will check if the given string starts with the given prefix.
+
+###### `str`<sup>Required</sup> <a name="str" id="ez-constructs.Utils.startsWith.parameter.str"></a>
+
+- *Type:* string
+
+a string.
+
+---
+
+###### `s`<sup>Required</sup> <a name="s" id="ez-constructs.Utils.startsWith.parameter.s"></a>
+
+- *Type:* string
+
+the prefix to check.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ A collection of heaviliy opinionated AWS CDK highlevel constructs.
 
 ## Constructs
 1. [SecureBucket](src/secure-bucket) - Creates an S3 bucket that is secure, encrypted at rest along with object retention and intelligent transition rules
+2. [SimpleCodeBuildProject](src/codebuild-ci) - Creates Codebuild projects the easy way. 
 
 ## Libraries
 1. Utils - A collection of utility functions
+2. CustomSynthesizer - A custom CDK synthesizer that will alter the default service roles that CDK uses. 
 
 ## Aspects
 1. [PermissionsBoundaryAspect](src/aspects) - A custom aspect that can be used to apply a permission boundary to all roles created in the contex. 

--- a/src/codebuild-ci/README.md
+++ b/src/codebuild-ci/README.md
@@ -1,0 +1,29 @@
+# SimpleCodebuildProject 
+
+**Motivation**
+
+Most of the cases,a developer will use CodeBuild setup to perform simple CI tasks such as:
+- Build and test your code on a PR
+- Run a specific script based on a cron schedule.
+
+Also, they might want:
+- Artifacts like testcase reports to be available via Reports tab and/or S3.
+- Logs to be available via CloudWatch Logs.
+
+However, there can be additional organizational retention policies, for example retaining logs for a particular period of time.
+
+With this construct, you can easily create a basic CodeBuild project with many opinated defaults that are compliant with FISMA and NISTThis construct provides an easy way to create basic CodeBuild project with a lot of opinated defaults that are in compliance with FISMA and NIST.
+
+Example, creates a project named `my-project`, with artifacts going to my-project-artifacts-<accountId>-<region>
+ and logs going to `/aws/codebuild/my-project` log group with a retention period of 90 days and 14 months respectively.
+
+```ts
+
+new SimpleCodebuildProject(stack, 'MyProject')
+   .projectName('myproject')
+   .gitRepoUrl('https://github.com/bijujoseph/cloudbiolinux.git')
+   .gitBaseBranch('main')
+   .triggerEvent(GitEvent.PULL_REQUEST)
+   .buildSpecPath('buildspecs/my-pr-checker.yml')
+   .assemble();
+```

--- a/src/codebuild-ci/index.ts
+++ b/src/codebuild-ci/index.ts
@@ -1,0 +1,359 @@
+import {
+  Artifacts, BuildSpec, ComputeType,
+  EventAction,
+  FilterGroup,
+  LinuxBuildImage,
+  Project,
+  ProjectProps,
+  Source,
+} from 'aws-cdk-lib/aws-codebuild';
+import { BuildEnvironmentVariable } from 'aws-cdk-lib/aws-codebuild/lib/project';
+import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
+import { CodeBuildProject } from 'aws-cdk-lib/aws-events-targets';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
+import { Bucket } from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+import { EzConstruct } from '../index';
+import { Utils } from '../lib/utils';
+import { SecureBucket } from '../secure-bucket';
+
+/**
+ * The Github events which should trigger this build.
+ */
+export enum GitEvent {
+  PULL_REQUEST = 'pull_request',
+  PUSH = 'push',
+  ALL = 'all',
+}
+
+/**
+ * Most of the cases,a developer will use CodeBuild setup to perform simple CI tasks such as:
+ * - Build and test your code on a PR
+ * - Run a specific script based on a cron schedule.
+ * Also, they might want:
+ * - artifacts like testcase reports to be available via Reports UI and/or S3.
+ * - logs to be available via CloudWatch Logs.
+ *
+ * However, there can be additional organizational retention policies, for example retaining logs for a particular period of time.
+ * With this construct, you can easily create a basic CodeBuild project with many opinated defaults that are compliant with FISMA and NISTThis construct provides an easy way to create basic CodeBuild project with a lot of opinated defaults that are in compliance with FISMA and NIST.
+ *
+ * Example, creates a project named `my-project`, with artifacts going to my-project-artifacts-<accountId>-<region>
+ *  and logs going to `/aws/codebuild/my-project` log group with a retention period of 90 days and 14 months respectively.
+ *
+ *    new SimpleCodebuildProject(stack, 'MyProject')
+ *      .projectName('myproject')
+ *      .gitRepoUrl('https://github.com/bijujoseph/cloudbiolinux.git')
+ *      .gitBaseBranch('main')
+ *      .triggerEvent(GitEvent.PULL_REQUEST)
+ *      .buildSpecPath('buildspecs/my-pr-checker.yml')
+ *      .assemble();
+ *
+ *
+ */
+export class SimpleCodebuildProject extends EzConstruct {
+
+  private _project: Project | undefined;
+  private _projectName?: string;
+  private _projectDescription?: string;
+  private _gitRepoUrl?: string;
+  private _gitBaseBranch: string = 'develop';
+  private _buildSpecPath?: string;
+  private _grantReportGroupPermissions = true;
+  private _triggerOnGitEvent?: GitEvent;
+  private _triggerOnSchedule?: Schedule;
+  private _artifactBucket?: Bucket | string;
+  private _envVariables: {
+    [name: string]: BuildEnvironmentVariable;
+  } = {};
+
+  // @ts-ignore
+  private _props: ProjectProps;
+
+  private readonly scope: Construct;
+  // @ts-ignore
+  private readonly id: string;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+    this.scope = scope;
+    this.id = id;
+  }
+
+  /**
+   * The underlying codebuild project that is created by this construct.
+   */
+  get project(): Project | undefined {
+    return this._project;
+  }
+
+  /**
+   * A convenient way to set the project environment variables.
+   * The values set here will be presnted on the UI when build with overriding is used.
+   * @param name - The environment variable name
+   * @param envVar - The environment variable value
+   *Example:
+   *
+   *  project
+   *    .addEnvironmentVariable('MY_ENV_VAR', {value: 'abcd})
+   *    .addEnvironmentVariable('MY_ENV_VAR', {value: '/dev/thatkey, type: BuildEnvironmentVariableType.PARAMETER_STORE})
+   *    .addEnvironmentVariable('MY_ENV_VAR', {value: 'arn:of:secret, type: BuildEnvironmentVariableType.SECRETS_MANAGER});
+   *
+   */
+  addEnv(name: string, envVar: BuildEnvironmentVariable): SimpleCodebuildProject {
+    this._envVariables[name] = envVar;
+    return this;
+  }
+
+  /**
+   * The name of the codebuild project
+   * @param projectName - a valid name string
+   */
+  projectName(projectName: string): SimpleCodebuildProject {
+    this._projectName = projectName;
+    return this;
+  }
+
+  /**
+   * The description of the codebuild project
+   * @param projectDescription - a valid description string
+   */
+  projectDescription(projectDescription: string): SimpleCodebuildProject {
+    this._projectDescription = projectDescription;
+    return this;
+  }
+
+  /**
+   * The build spec file path
+   * @param buildSpecPath - relative location of the build spec file
+   */
+  buildSpecPath(buildSpecPath: string): SimpleCodebuildProject {
+    this._buildSpecPath = buildSpecPath;
+    return this;
+  }
+
+  /**
+   * The github or enterprise github repository url
+   * @param gitRepoUrl
+   */
+  gitRepoUrl(gitRepoUrl: string): SimpleCodebuildProject {
+    this._gitRepoUrl = gitRepoUrl;
+    return this;
+  }
+
+  /**
+   * The main branch of the github project.
+   * @param branch
+   */
+  gitBaseBranch(branch: string): SimpleCodebuildProject {
+    this._gitBaseBranch = branch;
+    return this;
+  }
+
+  /**
+   * The Github events that can trigger this build.
+   * @param event
+   */
+  triggerBuildOnGitEvent(event: GitEvent): SimpleCodebuildProject {
+    this._triggerOnGitEvent = event;
+    return this;
+  }
+
+  /**
+   * The cron schedule on which this build gets triggerd.
+   * @param schedule
+   */
+  triggerBuildOnSchedule(schedule: Schedule): SimpleCodebuildProject {
+    this._triggerOnSchedule = schedule;
+    return this;
+  }
+
+  /**
+   * The name of the bucket to store the artifacts.
+   * By default the buckets will get stored in `<project-name>-artifacts` bucket.
+   * This function can be used to ovrride the default behavior.
+   * @param artifactBucket - a valid existing Bucket reference or bucket name to use.
+   */
+  artifactBucket(artifactBucket: Bucket | string): SimpleCodebuildProject {
+    this._artifactBucket = artifactBucket;
+    return this;
+  }
+
+  public overrideProjectProps(props: ProjectProps): SimpleCodebuildProject {
+    let projectName = this._projectName ? this._projectName : Utils.kebabCase(this.id);
+    let description = this._projectDescription ? this._projectDescription : `Codebuild description for ${projectName}`;
+
+    let defaults = {
+      projectName,
+      description,
+      grantReportGroupPermissions: this._grantReportGroupPermissions, // default to true
+    };
+
+    // set the default environment if not provided.
+    if (Utils.isEmpty(props.environment)) {
+      // @ts-ignore
+      defaults.environment = {
+        buildImage: LinuxBuildImage.STANDARD_5_0, // default to Amazon Linux 5.0
+        privileged: true,
+        computeType: ComputeType.MEDIUM,
+        environmentVariables: this._envVariables,
+      };
+    }
+
+    // add default logging if not provided
+    if (Utils.isEmpty(props.logging)) {
+      // @ts-ignore
+      defaults.logging = {
+        cloudWatch: {
+          logGroup: new LogGroup(this, 'ProjectLogGroup', {
+            logGroupName: `/aws/codebuild/${Utils.kebabCase(projectName)}`,
+            retention: RetentionDays.THIRTEEN_MONTHS,
+          }),
+        },
+      };
+    }
+
+    // create source if not provided in props
+    if (Utils.isEmpty(props.source)) {
+      // @ts-ignore
+      defaults.source = this.createSource(this._gitRepoUrl as string,
+        this._gitBaseBranch,
+        this._triggerOnGitEvent);
+    }
+
+    // create artifact bucket if one was not provided
+    if (Utils.isEmpty(props.artifacts)) {
+      // @ts-ignore
+      defaults.artifacts = this.createArtifacts(this._artifactBucket ?? `${this._projectName}-artifacts`);
+    }
+
+    // create the build spec if one was not provided
+    if (Utils.isEmpty(props.buildSpec) && !Utils.isEmpty(this._buildSpecPath)) {
+      // @ts-ignore
+      defaults.buildSpec = this.createBuildSpec(this._buildSpecPath as string);
+    }
+
+    this._props = Object.assign({}, defaults, props);
+
+    return this;
+  }
+
+
+  assemble(): SimpleCodebuildProject {
+    // create the default project properties
+    this.overrideProjectProps({});
+
+    // create a codebuild project
+    let project = new Project(this.scope, 'Project', this._props);
+
+    // run above project on a schedule ?
+    if (this._triggerOnSchedule) {
+      new Rule(this.scope, 'ScheduleRule', {
+        schedule: this._triggerOnSchedule,
+        targets: [new CodeBuildProject(project)],
+      });
+    }
+    this._project = project;
+    return this;
+  }
+
+  /**
+   * Create an S3 bucket for storing artifacts produced by the codebuild project
+   * @param bucketName - the s3 bucket
+   * @private
+   */
+  private createBucket(bucketName: string): Bucket {
+    return new SecureBucket(this, 'ProjectArtifactBucket')
+      .bucketName(bucketName)
+      .objectsExpireInDays(90)
+      .assemble()
+      .bucket as Bucket;
+  }
+
+  /**
+   * Creates an S3 artifact store for storing the objects produced by the codebuild project
+   * @param artifactBucket - a bucket object or bucket name
+   * @private
+   */
+  private createArtifacts(artifactBucket: Bucket | string): Artifacts {
+    let theBucket: Bucket = (typeof artifactBucket === 'string') ? this.createBucket(artifactBucket) : artifactBucket;
+    return Artifacts.s3({
+      bucket: theBucket,
+      includeBuildId: true,
+      packageZip: true,
+    });
+  }
+
+  /**
+   * Creates a Github or Enterprise Githb repo source object
+   * @param repoUrl - the url of the repo
+   * @param base - the main or base branch used by the repo
+   * @param gitEvent - the github events that can trigger builds
+   * @private
+   */
+  private createSource(repoUrl: string, base?: string, gitEvent?: GitEvent): Source {
+    let webhook = gitEvent && true;
+    let repoDetails = Utils.parseGithubUrl(repoUrl);
+    let webhookFilter = this.createWebHookFilters(base, gitEvent);
+
+    if (repoDetails.enterprise == true) {
+      return Source.gitHubEnterprise({
+        httpsCloneUrl: repoUrl,
+        webhook,
+        webhookFilters: webhookFilter,
+      });
+    }
+
+    return Source.gitHub({
+      owner: repoDetails.owner,
+      repo: repoDetails.repo,
+      webhook,
+      webhookFilters: webhookFilter,
+    });
+
+  }
+
+  /**
+   * Creates a webhook filter object
+   * @param base - the base branch
+   * @param gitEvent - the github event
+   * @private
+   */
+  private createWebHookFilters(base?: string, gitEvent?: GitEvent): FilterGroup[] | undefined {
+    // @ts-ignore
+    let fg: FilterGroup = null;
+
+    if (!gitEvent) return undefined;
+
+    if (gitEvent == GitEvent.PULL_REQUEST) {
+      fg = FilterGroup.inEventOf(EventAction.PULL_REQUEST_CREATED,
+        EventAction.PULL_REQUEST_UPDATED,
+        EventAction.PULL_REQUEST_REOPENED);
+      if (base) {
+        fg = fg.andBaseBranchIs(base);
+      }
+    }
+
+    if (gitEvent == GitEvent.PUSH) {
+      fg = FilterGroup.inEventOf(EventAction.PUSH);
+    }
+
+    if (gitEvent == GitEvent.ALL) {
+      fg = FilterGroup.inEventOf(EventAction.PUSH,
+        EventAction.PULL_REQUEST_CREATED,
+        EventAction.PULL_REQUEST_UPDATED,
+        EventAction.PULL_REQUEST_REOPENED,
+        EventAction.PULL_REQUEST_MERGED);
+    }
+    return [fg];
+  }
+
+  /**
+   * Loads the build spec associated with the given codebuild project
+   * @param buildSpecPath - location of the build spec file.
+   * @private
+   */
+  private createBuildSpec(buildSpecPath: string): BuildSpec {
+    return BuildSpec.fromSourceFilename(buildSpecPath);
+  }
+
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,13 @@
-export * from './secure-bucket';
+import { Construct } from 'constructs';
+
 export * from './lib/utils';
+
+/**
+ * A marker base class for EzConstructs
+ */
+export class EzConstruct extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
+}
+

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,5 @@
+import { Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import * as _ from 'lodash';
 
 /**
@@ -28,8 +30,74 @@ export class Utils {
    */
   public static wrap(str:string, delimiter:string): string {
     let newStr = str;
-    if (!_.startsWith(str, delimiter)) newStr = `${delimiter}${newStr}`;
-    if (!_.endsWith(str, delimiter)) newStr = `${newStr}${delimiter}`;
+    if (!Utils.startsWith(str, delimiter)) newStr = `${delimiter}${newStr}`;
+    if (!Utils.endsWith(str, delimiter)) newStr = `${newStr}${delimiter}`;
     return newStr;
   }
+
+  /**
+   * Will check if the given string starts with the given prefix.
+   * @param str - a string
+   * @param s - the prefix to check
+   */
+  public static startsWith(str:string, s:string): boolean {
+    return _.startsWith(str, s);
+  }
+
+  /**
+   * Will check if the given string ends with the given suffix.
+   * @param str - a string
+   * @param s - suffix to check
+   */
+  public static endsWith(str:string, s:string): boolean {
+    return _.endsWith(str, s);
+  }
+
+  /**
+   * Will check if the given object is empty
+   * @param value
+   */
+  public static isEmpty(value?: any): boolean {
+    return _.isEmpty(value);
+  }
+
+  /**
+   * Will convert the given string to lower case and transform any spaces to hyphens
+   * @param str - a string
+   */
+  public static kebabCase(str: string): string {
+    return _.kebabCase(_.toLower(str));
+  }
+
+  /**
+   * Splits a given Github URL and extracts the owner and repo name
+   * @param url
+   */
+  public static parseGithubUrl(url: string): any {
+    if (Utils.isEmpty(url)) throw new TypeError('Invalid URL');
+    if (!( Utils.startsWith(url, 'https://github.cms.gov/') || Utils.startsWith(url, 'https://github.com'))) throw new TypeError('Invalid URL');
+    if (!Utils.endsWith(url, '.git')) throw new TypeError('Invalid URL');
+
+    // find the details from url
+    let u = new URL(url);
+    let owner = u.pathname.split('/')[1];
+    let repo = _.replace(u.pathname.split('/')[2], '.git', '');
+    let enterprise = u.hostname == 'github.cms.gov';
+    let github = u.hostname == 'github.com';
+
+    if (_.isEmpty(owner) || _.isEmpty(repo)) throw new TypeError('Invalid URL');
+
+    return { owner, repo, github, enterprise };
+  }
+
+  /**
+   * A utility function that will print the content of a CDK stack.
+   * @warning This function is only used for debugging purpose.
+   * @param stack - a valid stack
+   */
+  public static prettyPrintStack(stack: Stack): void {
+    let t = Template.fromStack(stack);
+    console.log(JSON.stringify(t.toJSON(), null, 2));
+  }
+
 }

--- a/test/codebuild-ci/codebuild-ci.test.ts
+++ b/test/codebuild-ci/codebuild-ci.test.ts
@@ -1,0 +1,128 @@
+import { App, Stack } from 'aws-cdk-lib';
+import '@aws-cdk/assert/jest';
+import { Schedule } from 'aws-cdk-lib/aws-events';
+import { GitEvent, SimpleCodebuildProject } from '../../src/codebuild-ci';
+
+describe('SimpleCodebuildProject Construct', () => {
+
+  describe('GitEvent', () => {
+    test('enum values', () => {
+      expect(GitEvent.ALL).toEqual('all');
+      expect(GitEvent.PULL_REQUEST).toEqual('pull_request');
+      expect(GitEvent.PUSH).toEqual('push');
+    });
+  });
+
+
+  describe('Basic Project', () => {
+    let myapp: App;
+    let mystack: Stack;
+
+    beforeEach(() => {
+      // GIVEN
+      myapp = new App();
+      mystack = new Stack(myapp, 'mystack', {
+        env: {
+          account: '111111111111',
+          region: 'us-east-1',
+        },
+      });
+    });
+
+    test('default project', () => {
+      // WHEN
+      let p = new SimpleCodebuildProject(mystack, 'myproject')
+        .projectName('myproject')
+        .gitRepoUrl('https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git')
+        .gitBaseBranch('main')
+        .assemble();
+
+      // THEN should have a default project created
+      expect(p.project).toBeDefined();
+      expect(mystack).toHaveResourceLike('AWS::CodeBuild::Project', {
+        Name: 'myproject',
+        EncryptionKey: 'alias/aws/s3',
+        Source: {
+          ReportBuildStatus: true,
+          Location: 'https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git',
+          Type: 'GITHUB_ENTERPRISE',
+        },
+        Cache: {
+          Type: 'NO_CACHE',
+        },
+        Artifacts: {
+          Type: 'S3',
+          NamespaceType: 'BUILD_ID',
+          Packaging: 'ZIP',
+        },
+        Environment: {
+          ComputeType: 'BUILD_GENERAL1_MEDIUM',
+          Image: 'aws/codebuild/standard:5.0',
+        },
+      });
+
+      // THEN should contain a bucket with correct name
+      expect(mystack).toHaveResourceLike('AWS::S3::Bucket', {
+        BucketName: 'myproject-artifacts-111111111111-us-east-1',
+        LifecycleConfiguration: {
+          Rules: [
+            {
+              ExpirationInDays: 90,
+            },
+          ],
+        },
+      });
+
+    });
+    test('project PR build', () => {
+      // WHEN
+      new SimpleCodebuildProject(mystack, 'myproject')
+        .projectName('myproject')
+        .gitRepoUrl('https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git')
+        .gitBaseBranch('main')
+        .triggerBuildOnGitEvent(GitEvent.PULL_REQUEST)
+        .assemble();
+
+      // THEN should have a default project created
+      expect(mystack).toHaveResourceLike('AWS::CodeBuild::Project', {
+        Name: 'myproject',
+        Triggers: {
+          Webhook: true,
+          FilterGroups: [
+            [
+              {
+                Pattern: 'PULL_REQUEST_CREATED, PULL_REQUEST_UPDATED, PULL_REQUEST_REOPENED',
+                Type: 'EVENT',
+              },
+              {
+                Pattern: 'refs/heads/main',
+                Type: 'BASE_REF',
+              },
+            ],
+          ],
+        },
+
+      });
+
+
+    });
+    test('project Scheduled build', () => {
+      // WHEN
+      new SimpleCodebuildProject(mystack, 'myproject')
+        .projectName('myproject')
+        .gitRepoUrl('https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git')
+        .gitBaseBranch('main')
+        .triggerBuildOnSchedule(Schedule.cron({
+          minute: '0',
+          hour: '10',
+        }))
+        .assemble();
+
+      expect(mystack).toHaveResourceLike('AWS::Events::Rule', {
+        ScheduleExpression: 'cron(0 10 * * ? *)',
+        State: 'ENABLED',
+      });
+
+    });
+  });
+});

--- a/test/lib/utils.test.ts
+++ b/test/lib/utils.test.ts
@@ -31,4 +31,62 @@ describe('Utils', () => {
     });
   });
 
+  describe('startsWith', () => {
+
+    test('should be true', () => {
+      expect(Utils.startsWith('https://github.com/SavvyTools/ez-constructs.git', 'https://github.com/'))
+        .toBe(true);
+    });
+
+    test('should be true for entprise git url', () => {
+      expect(Utils.startsWith('https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git', 'https://github.cms.gov/'))
+        .toBe(true);
+    });
+
+    test('should be false', () => {
+      expect(Utils.startsWith('https://github.com/SavvyTools/ez-constructs.git', 'github.com/'))
+        .toBe(false);
+    });
+
+  });
+  describe('endsWith', () => {
+
+    test('should be true', () => {
+      expect(Utils.endsWith('https://github.com/SavvyTools/ez-constructs.git', '.git'))
+        .toBe(true);
+    });
+
+    test('should be false', () => {
+      expect(Utils.startsWith('https://github.com/SavvyTools/ez-constructs.git', 'abcd'))
+        .toBe(false);
+    });
+
+  });
+
+  describe('parseGithubUrl', () => {
+
+    test('should get the right owner and repo name for org repos', () => {
+      expect(Utils.parseGithubUrl('https://github.com/SavvyTools/ez-constructs.git'))
+        .toEqual({ owner: 'SavvyTools', repo: 'ez-constructs', github: true, enterprise: false });
+    });
+
+    test('should get the right owner and repo name for non org repos', () => {
+      expect(Utils.parseGithubUrl('https://github.com/bijujoseph/cloudbiolinux.git'))
+        .toEqual({ owner: 'bijujoseph', repo: 'cloudbiolinux', github: true, enterprise: false });
+    });
+
+    test('should parse enterprise github url properly', () => {
+      expect(Utils.parseGithubUrl('https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git'))
+        .toEqual({ owner: 'qpp', repo: 'qpp-integration-test-infrastructure-cdk', github: false, enterprise: true });
+    });
+
+    test('should throw error when url is not provided ', () => {
+      expect(() => Utils.parseGithubUrl('')).toThrowError('Invalid URL');
+    });
+
+    test('should throw error when url is not having all parts ', () => {
+      expect(() => Utils.parseGithubUrl('https://hello.com')).toThrowError('Invalid URL');
+    });
+  });
+
 });

--- a/test/secure-bucket/secure-bucket.test.ts
+++ b/test/secure-bucket/secure-bucket.test.ts
@@ -22,9 +22,7 @@ describe('SecureBucket Construct', () => {
     test('default bucket parameters', () => {
 
       // WHEN
-      new SecureBucket(mystack, 'secureBucket', {
-        bucketName: 'mybucket',
-      });
+      new SecureBucket(mystack, 'secureBucket').bucketName('mybucket').assemble();
 
       // THEN should have correct name
       expect(mystack).toHaveResourceLike('AWS::S3::Bucket', {
@@ -103,10 +101,10 @@ describe('SecureBucket Construct', () => {
 
     test('bucket version disabled', () => {
       // WHEN
-      new SecureBucket(mystack, 'secureBucket', {
-        bucketName: 'mybucket',
-        versioned: false,
-      });
+      new SecureBucket(mystack, 'secureBucket')
+        .bucketName('mybucket')
+        .overrideBucketProperties({ versioned: false })
+        .assemble();
 
 
       expect(mystack).not.toHaveResourceLike('AWS::S3::Bucket', {
@@ -136,10 +134,10 @@ describe('SecureBucket Construct', () => {
 
     test('bucket that override expiration', () => {
       // WHEN
-      new SecureBucket(mystack, 'secureBucket', {
-        bucketName: 'mybucket',
-        objectsExpireInDays: 500,
-      });
+      new SecureBucket(mystack, 'secureBucket')
+        .bucketName('mybucket')
+        .objectsExpireInDays(500)
+        .assemble();
 
       // THEN
       expect(mystack).toHaveResourceLike('AWS::S3::Bucket', {
@@ -176,10 +174,10 @@ describe('SecureBucket Construct', () => {
     });
     test('bucket that override expiration below 90 days', () => {
       // WHEN
-      new SecureBucket(mystack, 'secureBucket', {
-        bucketName: 'mybucket',
-        objectsExpireInDays: 89,
-      });
+      new SecureBucket(mystack, 'secureBucket')
+        .bucketName('mybucket')
+        .objectsExpireInDays(89)
+        .assemble();
 
       // THEN no transition should be present
       expect(mystack).toHaveResourceLike('AWS::S3::Bucket', {
@@ -201,11 +199,10 @@ describe('SecureBucket Construct', () => {
     });
     test('bucket that override expiration below 60 days', () => {
       // WHEN
-      new SecureBucket(mystack, 'secureBucket', {
-        bucketName: 'mybucket',
-        objectsExpireInDays: 59,
-      });
-
+      new SecureBucket(mystack, 'secureBucket')
+        .bucketName('mybucket')
+        .objectsExpireInDays(59)
+        .assemble();
 
       // THEN has the correct object expiration added
       expect(mystack).toHaveResourceLike('AWS::S3::Bucket', {
@@ -237,11 +234,11 @@ describe('SecureBucket Construct', () => {
     });
     test('bucket that is not SSL enabled', () => {
       // WHEN
-      new SecureBucket(mystack, 'secureBucket', {
-        bucketName: 'mybucket',
-        objectsExpireInDays: 500,
-        enforceSSL: false,
-      });
+      new SecureBucket(mystack, 'secureBucket')
+        .bucketName('mybucket')
+        .objectsExpireInDays(500)
+        .overrideBucketProperties({ enforceSSL: false })
+        .assemble();
 
       // THEN
       expect(mystack).not.toHaveResourceLike('AWS::S3::BucketPolicy', {


### PR DESCRIPTION
# SimpleCodebuildProject 

**Motivation**

Most of the cases,a developer will use CodeBuild setup to perform simple CI tasks such as:
- Build and test your code on a PR
- Run a specific script based on a cron schedule.

Also, they might want:
- Artifacts like testcase reports to be available via Reports tab and/or S3.
- Logs to be available via CloudWatch Logs.

However, there can be additional organizational retention policies, for example retaining logs for a particular period of time.

With this construct, you can easily create a basic CodeBuild project with many opinated defaults that are compliant with FISMA and NISTThis construct provides an easy way to create basic CodeBuild project with a lot of opinated defaults that are in compliance with FISMA and NIST.

Example, creates a project named `my-project`, with artifacts going to my-project-artifacts-<accountId>-<region>
 and logs going to `/aws/codebuild/my-project` log group with a retention period of 90 days and 14 months respectively.

```ts

new SimpleCodebuildProject(stack, 'MyProject')
   .projectName('myproject')
   .gitRepoUrl('https://github.com/bijujoseph/cloudbiolinux.git')
   .gitBaseBranch('main')
   .triggerEvent(GitEvent.PULL_REQUEST)
   .buildSpecPath('buildspecs/my-pr-checker.yml')
   .assemble();
```

