### PR TITLE
chore: updating the export

### DIFF
--- a/src/secure-bucket/index.ts
+++ b/src/secure-bucket/index.ts
@@ -1,6 +1,5 @@
 import { Duration, Stack } from 'aws-cdk-lib';
-import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
-import { StarPrincipal } from 'aws-cdk-lib/aws-iam/lib/principals';
+import { Effect, PolicyStatement, StarPrincipal } from 'aws-cdk-lib/aws-iam';
 import { BlockPublicAccess, Bucket, BucketEncryption, BucketProps, StorageClass } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import * as _ from 'lodash';


### PR DESCRIPTION
Fixes #
```
Package subpath './aws-iam/lib/principals' is not defined by "exports" in /codebuild/output/src436122044/src/github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk/infrastructure/cdk/node_modules/aws-cdk-lib/package.json
Subprocess exited with error 1
```