### PR TITLE
feat: Adding privileged mode flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ jspm_packages/
 cdk.context.json
 cdk.out/
 *.dot
+/tmp
 !/.projenrc.js
 /test-reports/
 junit.xml

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -12,6 +12,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'cdk.out/',
     '*.dot',
     '/.idea',
+    '/tmp',
   ],
   releaseToNpm: true,
   devDeps: [

--- a/API.md
+++ b/API.md
@@ -1118,7 +1118,7 @@ Splits a given Github URL and extracts the owner and repo name.
 ```typescript
 import { Utils } from 'ez-constructs'
 
-Utils.prettyPrintStack(stack: Stack)
+Utils.prettyPrintStack(stack: Stack, persist?: boolean)
 ```
 
 A utility function that will print the content of a CDK stack.
@@ -1128,6 +1128,12 @@ A utility function that will print the content of a CDK stack.
 - *Type:* aws-cdk-lib.Stack
 
 a valid stack.
+
+---
+
+###### `persist`<sup>Optional</sup> <a name="persist" id="ez-constructs.Utils.prettyPrintStack.parameter.persist"></a>
+
+- *Type:* boolean
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1118,7 +1118,7 @@ Splits a given Github URL and extracts the owner and repo name.
 ```typescript
 import { Utils } from 'ez-constructs'
 
-Utils.prettyPrintStack(stack: Stack, persist?: boolean)
+Utils.prettyPrintStack(stack: Stack)
 ```
 
 A utility function that will print the content of a CDK stack.
@@ -1128,12 +1128,6 @@ A utility function that will print the content of a CDK stack.
 - *Type:* aws-cdk-lib.Stack
 
 a valid stack.
-
----
-
-###### `persist`<sup>Optional</sup> <a name="persist" id="ez-constructs.Utils.prettyPrintStack.parameter.persist"></a>
-
-- *Type:* boolean
 
 ---
 

--- a/API.md
+++ b/API.md
@@ -1141,7 +1141,7 @@ Splits a given Github URL and extracts the owner and repo name.
 ```typescript
 import { Utils } from 'ez-constructs'
 
-Utils.prettyPrintStack(stack: Stack)
+Utils.prettyPrintStack(stack: Stack, persist?: boolean)
 ```
 
 A utility function that will print the content of a CDK stack.
@@ -1151,6 +1151,12 @@ A utility function that will print the content of a CDK stack.
 - *Type:* aws-cdk-lib.Stack
 
 a valid stack.
+
+---
+
+###### `persist`<sup>Optional</sup> <a name="persist" id="ez-constructs.Utils.prettyPrintStack.parameter.persist"></a>
+
+- *Type:* boolean
 
 ---
 

--- a/src/codebuild-ci/index.ts
+++ b/src/codebuild-ci/index.ts
@@ -60,6 +60,7 @@ export class SimpleCodebuildProject extends EzConstruct {
   private _gitBaseBranch: string = 'develop';
   private _buildSpecPath?: string;
   private _grantReportGroupPermissions = true;
+  private _privileged = false;
   private _triggerOnGitEvent?: GitEvent;
   private _triggerOnSchedule?: Schedule;
   private _artifactBucket?: IBucket | string;
@@ -136,6 +137,19 @@ export class SimpleCodebuildProject extends EzConstruct {
   }
 
   /**
+   * Set privileged mode of execution. Usually needed if this project builds Docker images,
+   * and the build environment image you chose is not provided by CodeBuild with Docker support.
+   * By default, Docker containers do not allow access to any devices.
+   * Privileged mode grants a build project's Docker container access to all devices
+   * https://docs.aws.amazon.com/codebuild/latest/userguide/change-project-console.html#change-project-console-environment
+   * @param p - true/false
+   */
+  privileged(p: boolean): SimpleCodebuildProject {
+    this._privileged = p;
+    return this;
+  }
+
+  /**
    * The build spec file path
    * @param buildSpecPath - relative location of the build spec file
    */
@@ -206,7 +220,7 @@ export class SimpleCodebuildProject extends EzConstruct {
       // @ts-ignore
       defaults.environment = {
         buildImage: LinuxBuildImage.STANDARD_5_0, // default to Amazon Linux 5.0
-        privileged: false,
+        privileged: this._privileged,
         computeType: this._computType,
         environmentVariables: this._envVariables,
       };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import { Stack } from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { NagSuppressions } from 'cdk-nag';
@@ -30,7 +31,7 @@ export class Utils {
    * @param delimiter - the delimiter to use
    * @returns the wrapped string
    */
-  public static wrap(str:string, delimiter:string): string {
+  public static wrap(str: string, delimiter: string): string {
     let newStr = str;
     if (!Utils.startsWith(str, delimiter)) newStr = `${delimiter}${newStr}`;
     if (!Utils.endsWith(str, delimiter)) newStr = `${newStr}${delimiter}`;
@@ -42,7 +43,7 @@ export class Utils {
    * @param str - a string
    * @param s - the prefix to check
    */
-  public static startsWith(str:string, s:string): boolean {
+  public static startsWith(str: string, s: string): boolean {
     return _.startsWith(str, s);
   }
 
@@ -51,7 +52,7 @@ export class Utils {
    * @param str - a string
    * @param s - suffix to check
    */
-  public static endsWith(str:string, s:string): boolean {
+  public static endsWith(str: string, s: string): boolean {
     return _.endsWith(str, s);
   }
 
@@ -77,7 +78,7 @@ export class Utils {
    */
   public static parseGithubUrl(url: string): any {
     if (Utils.isEmpty(url)) throw new TypeError('Invalid URL');
-    if (!( Utils.startsWith(url, 'https://github.cms.gov/') || Utils.startsWith(url, 'https://github.com'))) throw new TypeError('Invalid URL');
+    if (!(Utils.startsWith(url, 'https://github.cms.gov/') || Utils.startsWith(url, 'https://github.com'))) throw new TypeError('Invalid URL');
     if (!Utils.endsWith(url, '.git')) throw new TypeError('Invalid URL');
 
     // find the details from url
@@ -89,7 +90,12 @@ export class Utils {
 
     if (_.isEmpty(owner) || _.isEmpty(repo)) throw new TypeError('Invalid URL');
 
-    return { owner, repo, github, enterprise };
+    return {
+      owner,
+      repo,
+      github,
+      enterprise,
+    };
   }
 
   /**
@@ -97,9 +103,12 @@ export class Utils {
    * @warning This function is only used for debugging purpose.
    * @param stack - a valid stack
    */
-  public static prettyPrintStack(stack: Stack): void {
+  public static prettyPrintStack(stack: Stack, persist = true): void {
     let t = Template.fromStack(stack);
     console.log(JSON.stringify(t.toJSON(), null, 2));
+    if (persist) {
+      fs.writeFileSync(`tmp/${stack.stackName}.json`, JSON.stringify(t.toJSON(), null, 2));
+    }
   }
 
   /**

--- a/test/codebuild-ci/codebuild-ci.test.ts
+++ b/test/codebuild-ci/codebuild-ci.test.ts
@@ -5,7 +5,6 @@ import { ComputeType, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
 import { Schedule } from 'aws-cdk-lib/aws-events';
 import { AwsSolutionsChecks } from 'cdk-nag';
 import { GitEvent, SimpleCodebuildProject } from '../../src';
-import { Utils } from '../../src/lib/utils';
 
 
 describe('SimpleCodebuildProject Construct', () => {
@@ -167,7 +166,6 @@ describe('SimpleCodebuildProject Construct', () => {
           },
         });
 
-      Utils.prettyPrintStack(mystack);
 
       expect(mystack).toHaveResourceLike('AWS::CodeBuild::Project', {
         Environment: {

--- a/test/codebuild-ci/codebuild-ci.test.ts
+++ b/test/codebuild-ci/codebuild-ci.test.ts
@@ -153,7 +153,6 @@ describe('SimpleCodebuildProject Construct', () => {
         .projectName('myproject')
         .gitRepoUrl('https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git')
         .gitBaseBranch('main')
-        .privileged(true)
         .assemble({
           environment: {
             buildImage: LinuxBuildImage.STANDARD_5_0, // default to Amazon Linux 5.0


### PR DESCRIPTION
Fixes #15 

There are two ways to set the privileged flag. The traditional way is to use assembly time overriding. 
```
new SimpleCodebuildProject(mystack, 'myproject')
        .projectName('myproject')
        .gitRepoUrl('https://github.com/bijujoseph/mrepo.git')
        .gitBaseBranch('main')
        .assemble({
          environment: {
            buildImage: LinuxBuildImage.STANDARD_5_0, // default to Amazon Linux 5.0
            privileged: true,
            computeType: ComputeType.MEDIUM,
            environmentVariables: {
              TIER: { value: 'QA' },
              CYPRESS_REPORTS: { value: true },
            },
          },
        });
```

As you can see above, when you override the environment, the `SimpleCodebuildProject` rely on user to supply all the environment specific default values like `buildImage`, `computeType` etc, which may be overwhelming.  So a much simpler API enhancement is made as part of this PR as shown in the sample snippet below: 
```
new SimpleCodebuildProject(mystack, 'myproject')
        .projectName('myproject')
        .gitRepoUrl('https://github.com/bijujoseph/mrepo.git')
        .gitBaseBranch('main')
        .privileged(true).    /// NEWLY ADDED
        .assemble();

```