### PR TITLE
feat: Add PULL_REQUEST_MERGED option to SimpleCodebuildProject 

### DIFF
--- a/API.md
+++ b/API.md
@@ -1340,12 +1340,18 @@ The Github events which should trigger this build.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#ez-constructs.GitEvent.PULL_REQUEST">PULL_REQUEST</a></code> | *No description.* |
+| <code><a href="#ez-constructs.GitEvent.PULL_REQUEST_MERGED">PULL_REQUEST_MERGED</a></code> | *No description.* |
 | <code><a href="#ez-constructs.GitEvent.PUSH">PUSH</a></code> | *No description.* |
 | <code><a href="#ez-constructs.GitEvent.ALL">ALL</a></code> | *No description.* |
 
 ---
 
 ##### `PULL_REQUEST` <a name="PULL_REQUEST" id="ez-constructs.GitEvent.PULL_REQUEST"></a>
+
+---
+
+
+##### `PULL_REQUEST_MERGED` <a name="PULL_REQUEST_MERGED" id="ez-constructs.GitEvent.PULL_REQUEST_MERGED"></a>
 
 ---
 

--- a/src/codebuild-ci/index.ts
+++ b/src/codebuild-ci/index.ts
@@ -27,6 +27,7 @@ import { SecureBucket } from '../secure-bucket';
  */
 export enum GitEvent {
   PULL_REQUEST = 'pull_request',
+  PULL_REQUEST_MERGED = 'pull_request_merged',
   PUSH = 'push',
   ALL = 'all',
 }
@@ -417,6 +418,13 @@ export class SimpleCodebuildProject extends EzConstruct {
       fg1 = FilterGroup.inEventOf(EventAction.PULL_REQUEST_CREATED,
         EventAction.PULL_REQUEST_UPDATED,
         EventAction.PULL_REQUEST_REOPENED);
+      if (base) {
+        fg1 = fg1.andBaseBranchIs(base);
+      }
+    }
+
+    if (gitEvent == GitEvent.PULL_REQUEST_MERGED) {
+      fg1 = FilterGroup.inEventOf(EventAction.PULL_REQUEST_MERGED);
       if (base) {
         fg1 = fg1.andBaseBranchIs(base);
       }

--- a/test/codebuild-ci/codebuild-ci.test.ts
+++ b/test/codebuild-ci/codebuild-ci.test.ts
@@ -13,6 +13,7 @@ describe('SimpleCodebuildProject Construct', () => {
     test('enum values', () => {
       expect(GitEvent.ALL).toEqual('all');
       expect(GitEvent.PULL_REQUEST).toEqual('pull_request');
+      expect(GitEvent.PULL_REQUEST_MERGED).toEqual('pull_request_merged');
       expect(GitEvent.PUSH).toEqual('push');
     });
   });
@@ -161,6 +162,36 @@ describe('SimpleCodebuildProject Construct', () => {
       });
 
 
+    });
+    test('project PR merged build', () => {
+      // WHEN
+      new SimpleCodebuildProject(mystack, 'myproject')
+        .projectName('myproject')
+        .gitRepoUrl('https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git')
+        .gitBaseBranch('main')
+        .triggerBuildOnGitEvent(GitEvent.PULL_REQUEST_MERGED)
+        .assemble();
+
+      // THEN should have a default project created
+      expect(mystack).toHaveResourceLike('AWS::CodeBuild::Project', {
+        Name: 'myproject',
+        Triggers: {
+          Webhook: true,
+          FilterGroups: [
+            [
+              {
+                Pattern: 'PULL_REQUEST_MERGED',
+                Type: 'EVENT',
+              },
+              {
+                Pattern: 'refs/heads/main',
+                Type: 'BASE_REF',
+              },
+            ],
+          ],
+        },
+
+      });
     });
     test('project Scheduled build', () => {
       // WHEN


### PR DESCRIPTION
Allows `PULL_REQUEST_MERGED` for use in cases where the user only wants to build when a PR is merged into the base branch.