### PR TITLE
feat: Support for %replacement% values

### DIFF
--- a/API.md
+++ b/API.md
@@ -1373,6 +1373,7 @@ Any object.
 | <code><a href="#ez-constructs.SimpleServerlessSparkJob.property.stateMachine">stateMachine</a></code> | <code>aws-cdk-lib.aws_stepfunctions.StateMachine</code> | The state machine instance created by this construct. |
 | <code><a href="#ez-constructs.SimpleServerlessSparkJob.property.stateMachineRole">stateMachineRole</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | *No description.* |
 | <code><a href="#ez-constructs.SimpleServerlessSparkJob.property.stateDefinition">stateDefinition</a></code> | <code>string \| aws-cdk-lib.aws_stepfunctions.IChainable</code> | Sets the state definition, and if type of the value passed is a string, will also set the stateDefinition when it is a string. |
+| <code><a href="#ez-constructs.SimpleServerlessSparkJob.property.replacerLambdaFn">replacerLambdaFn</a></code> | <code>aws-cdk-lib.aws_lambda.SingletonFunction</code> | *No description.* |
 | <code><a href="#ez-constructs.SimpleServerlessSparkJob.property.validatorLambdaFn">validatorLambdaFn</a></code> | <code>aws-cdk-lib.aws_lambda.SingletonFunction</code> | *No description.* |
 
 ---
@@ -1506,6 +1507,16 @@ public readonly stateDefinition: string | IChainable;
 - *Type:* string | aws-cdk-lib.aws_stepfunctions.IChainable
 
 Sets the state definition, and if type of the value passed is a string, will also set the stateDefinition when it is a string.
+
+---
+
+##### `replacerLambdaFn`<sup>Required</sup> <a name="replacerLambdaFn" id="ez-constructs.SimpleServerlessSparkJob.property.replacerLambdaFn"></a>
+
+```typescript
+public readonly replacerLambdaFn: SingletonFunction;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.SingletonFunction
 
 ---
 

--- a/src/stepfunctions/README.md
+++ b/src/stepfunctions/README.md
@@ -29,19 +29,32 @@ new SimpleServerlessSparkJob(mystack, 'SingleFly', 'C2QProcessingETL')
         .logBucket('my-log-bucket-name')
         .usingDefinition({
           jobName: 'mytestjob',
-          entryPoint: 's3://my-artifact-bucket-222224444433-us-east-1/biju_test_files/myspark-assembly.jar',
+          entryPoint: 's3://my-artifact-bucket-222224444433-us-east-1/%commitId%/myspark-assembly.jar',
           mainClass: 'serverless.SimpleSparkApp',
           enableMonitoring: true,
         })
     .defaultParameters({
         "movie": {
-            "primeVideo": "No Country for Old Men"
+            "primeVideo": "No Country for Old Men release in %month%"
         },
         "month": "August"
     })
     .assemble();
 ```
 In the above case, in addition to the `EntryPoint` and `SparkSubmitParameters`, while starting execution one could override the `movie` and `month` parameter as well.
+
+> **Note**
+> Have you observed the `%month%` and `%commitId%` placeholders? 
+> 
+> Anything enclosed in `%%` will be dynamically replaced with the corresponding runtime context values, and this replacement happens recursively.
+>
+> In this specific scenario, the `month` value is already set to `August`, which will be used when generating the values for `primeVideo`. Additionally, the entryPoint will incorporate its file path with the `commitId` value you provide as input during the initiation of the step function execution.
+
+
+
+
+
+
 
 What if you prefer to create your own spark serverless workflow or have an serverless workflow that has many steps. In such circumstances, you could supply your custom workflow definition as shown below:
 ```ts

--- a/test/stepfunctions/serverless-spark-job.test.ts
+++ b/test/stepfunctions/serverless-spark-job.test.ts
@@ -252,6 +252,7 @@ describe('SimpleServerlessSparkJob Construct', () => {
 
     });
 
+
     test('job configuration template without entry point args', () => {
       // WHEN
       new SimpleServerlessSparkJob(mystack, 'SingleFly', 'MyTestETL')
@@ -279,6 +280,33 @@ describe('SimpleServerlessSparkJob Construct', () => {
       expect(entryArgsValid).not.toBeDefined();
     });
 
+
+    test('job configuration template with replacements', () => {
+      // WHEN
+      new SimpleServerlessSparkJob(mystack, 'SingleFly', 'MyTestETL')
+        .jobRole('delegatedadmin/developer/blames-emr-serverless-job-role')
+        .applicationId('12345676')
+        .logBucket('mylogbucket')
+        .usingSparkJobTemplate({
+          jobName: 'mytestjob-%country%',
+          entryPoint: 's3://aws-cms-amg-qpp-costscoring-artifact-dev-222224444433-us-east-1/%commitId%/myspark-assembly.jar',
+          mainClass: 'serverless.SimpleSparkApp',
+          enableMonitoring: true,
+        })
+        .withDefaultInputs({
+          age: 10,
+          country: 'USA',
+          message: 'This is from %commitId%',
+        })
+        .assemble();
+
+
+      // THEN should have a modified ASL.
+      let stateDef = Utils.fetchStepFuncitonStateDefinition(mystack);
+      console.log(JSON.stringify(stateDef, null, 2));
+      let replacerFn = stateDef.States.ReplacerFnInvoke;
+      expect(replacerFn).toBeDefined();
+    });
 
   });
 


### PR DESCRIPTION
As part of this feature, a node will be added to the the step functions workflow, to replace the data enclosed in `%%`. 
Example:
```javascript

      new SimpleServerlessSparkJob(mystack, 'SingleFly', 'MyTestETL')
        .jobRole('delegatedadmin/developer/blames-emr-serverless-job-role')
        .applicationId('12345676')
        .logBucket('mylogbucket')
        .usingSparkJobTemplate({
          jobName: 'mytestjob-%country%',
          entryPoint: 's3://aws-cms-amg-qpp-costscoring-artifact-dev-222224444433-us-east-1/%commitId%/myspark-assembly.jar',
          mainClass: 'serverless.SimpleSparkApp',
          enableMonitoring: true,
        })
        .withDefaultInputs({
          age: 10,
          country: 'USA',
          message: 'This is from %commitId%',
          address: {
            home: '9805 Capilano Dr. %country%',
            office: '321 Farifax VA, %country%',
          },
        })
        .assemble();
```

Before actually invoking the spark job, the values in `%%` will be replaced with values obtained from context. 
`address.home` will have a value of `'9805 Capilano Dr. USA'` and the same happens for `jobName`. If `commitId` is provided as `a45b` while starting execution, the values of `message` and `entryPoint` will be replaced to have those. 
Note:- if a replacement value is not available in the context, the string is retained as is. 

