### PR TITLE
feat: add ability to skip artifact creation

### DIFF
--- a/API.md
+++ b/API.md
@@ -2574,7 +2574,7 @@ the permission boundary to attach to newly created roles.
 ##### `modifyRolePath` <a name="modifyRolePath" id="ez-constructs.PermissionsBoundaryAspect.modifyRolePath"></a>
 
 ```typescript
-public modifyRolePath(roleResource: CfnRole, stack: Stack): void
+public modifyRolePath(roleResource: CfnRole, stack: Stack, skipBoundary?: boolean): void
 ```
 
 ###### `roleResource`<sup>Required</sup> <a name="roleResource" id="ez-constructs.PermissionsBoundaryAspect.modifyRolePath.parameter.roleResource"></a>
@@ -2586,6 +2586,12 @@ public modifyRolePath(roleResource: CfnRole, stack: Stack): void
 ###### `stack`<sup>Required</sup> <a name="stack" id="ez-constructs.PermissionsBoundaryAspect.modifyRolePath.parameter.stack"></a>
 
 - *Type:* aws-cdk-lib.Stack
+
+---
+
+###### `skipBoundary`<sup>Optional</sup> <a name="skipBoundary" id="ez-constructs.PermissionsBoundaryAspect.modifyRolePath.parameter.skipBoundary"></a>
+
+- *Type:* boolean
 
 ---
 

--- a/src/codebuild-ci/index.ts
+++ b/src/codebuild-ci/index.ts
@@ -67,6 +67,7 @@ export class SimpleCodebuildProject extends EzConstruct {
   private _buildSpecPath?: string;
   private _grantReportGroupPermissions = true;
   private _privileged = false;
+  private _skipArtifacts = false;
   private _triggerOnGitEvent?: GitEvent;
   private _triggerOnSchedule?: Schedule;
   private _triggerOnPushToBranches:Array<string> = [];
@@ -192,6 +193,15 @@ export class SimpleCodebuildProject extends EzConstruct {
   }
 
   /**
+   * If set, will skip artifact creation
+   * @param skip
+   */
+  skipArtifacts(skip:boolean): SimpleCodebuildProject {
+    this._skipArtifacts = skip;
+    return this;
+  }
+
+  /**
    * The build spec file path
    * @param buildSpecPath - relative location of the build spec file
    */
@@ -299,7 +309,7 @@ export class SimpleCodebuildProject extends EzConstruct {
     }
 
     // create artifact bucket if one was not provided
-    if (Utils.isEmpty(props.artifacts)) {
+    if (!this._skipArtifacts && Utils.isEmpty(props.artifacts)) {
       // @ts-ignore
       defaults.artifacts = this.createArtifacts(this._artifactBucket ?? `${this._projectName}-artifacts`);
     }
@@ -368,6 +378,7 @@ export class SimpleCodebuildProject extends EzConstruct {
       bucket: theBucket,
       includeBuildId: true,
       packageZip: true,
+      path: this._projectName,
     });
   }
 

--- a/test/aspects/permission-boundary-aspects.test.ts
+++ b/test/aspects/permission-boundary-aspects.test.ts
@@ -1,6 +1,6 @@
 import { App, Aspects, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import '@aws-cdk/assert/jest';
-import { PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { InstanceProfile, PolicyStatement, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { SecureBucket } from '../../lib';
 import { PermissionsBoundaryAspect } from '../../src/aspects/permission-boundary-aspect';
@@ -19,6 +19,11 @@ export class MyStack extends Stack {
       resources: ['*'],
       actions: ['lambda:InvokeFunction'],
     }));
+
+    new InstanceProfile(this, 'MyProfile', {
+      role: role,
+      instanceProfileName: 'bj-test-profile',
+    });
 
     new SecureBucket(this, 'myBucket')
       .bucketName('myworld')
@@ -41,6 +46,10 @@ describe('PermissionBoundaryAspect', () => {
     expect(mystack).toHaveResourceLike('AWS::IAM::Role', {
       Path: '/role/dev/',
       PermissionsBoundary: 'arn:aws:iam::111111111111:policy/boundary/dev',
+    });
+
+    expect(mystack).toHaveResourceLike('AWS::IAM::InstanceProfile', {
+      Path: '/role/dev/',
     });
 
   });

--- a/test/codebuild-ci/codebuild-ci.test.ts
+++ b/test/codebuild-ci/codebuild-ci.test.ts
@@ -250,6 +250,29 @@ describe('SimpleCodebuildProject Construct', () => {
 
     });
 
+    test('project without artifacts', () => {
+      // WHEN
+      let p = new SimpleCodebuildProject(mystack, 'myproject')
+        .projectName('myproject')
+        .gitRepoUrl('https://github.cms.gov/qpp/qpp-integration-test-infrastructure-cdk.git')
+        .gitBaseBranch('main')
+        .skipArtifacts(true)
+        .assemble();
+
+      // THEN should have a default project created
+      expect(p.project).toBeDefined();
+      expect(mystack).toHaveResourceLike('AWS::CodeBuild::Project', {
+        Artifacts: {
+          Type: 'NO_ARTIFACTS',
+        },
+      });
+
+      // THEN should contain a bucket with correct name
+      expect(mystack).not.toHaveResourceLike('AWS::S3::Bucket', {
+        BucketName: 'myproject-artifacts-111111111111-us-east-1',
+      });
+
+    });
 
     test('project environment privileged mode via overrides', () => {
       // WHEN


### PR DESCRIPTION
Codebuild jobs now can skip artifacts if needed
```

    test('project without artifacts', () => {
      // WHEN
      let p = new SimpleCodebuildProject(mystack, 'myproject')
        .projectName('myproject')
        .gitRepoUrl('https://github.com/myrepo.git')
        .gitBaseBranch('main')
        .skipArtifacts(true) // <<< skiping
        .assemble();

      // THEN should have a default project created
      expect(p.project).toBeDefined();
      expect(mystack).toHaveResourceLike('AWS::CodeBuild::Project', {
        Artifacts: {
          Type: 'NO_ARTIFACTS',
        },
      });

      // THEN should contain a bucket with correct name
      expect(mystack).not.toHaveResourceLike('AWS::S3::Bucket', {
        BucketName: 'myproject-artifacts-111111111111-us-east-1',
      });

    });
```